### PR TITLE
[RFR] Fix email wrong usage into getAutologinUrl method

### DIFF
--- a/src/Service/Rest/Client/Uberall/Uberall.php
+++ b/src/Service/Rest/Client/Uberall/Uberall.php
@@ -38,7 +38,6 @@ class Uberall extends UberallClient
         $user = $this->userClient->getByEmail($connectedUserEmail);
 
         if (isset($email)) {
-            $email = $connectedUserEmail;
             $client = $this->userClient->getByEmail($email);
         } else {
             $client = $user;


### PR DESCRIPTION
The $email parameter was erased by the $connectedUserEmail one.